### PR TITLE
Bring back support for the .NET scripting backend

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scenes/InteractablesGallery.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scenes/InteractablesGallery.unity
@@ -319,6 +319,12 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 114718788154663760, guid: 51cc6641d88b49d46bd38572540efe6c,
         type: 2}
+      propertyPath: Events.Array.data[0].AssemblyQualifiedName
+      value: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events.InteractableAudioReceiver,
+        Microsoft.MixedReality.Toolkit.SDK
+      objectReference: {fileID: 0}
+    - target: {fileID: 114718788154663760, guid: 51cc6641d88b49d46bd38572540efe6c,
+        type: 2}
       propertyPath: Events.Array.data[0].HideUnityEvents
       value: 1
       objectReference: {fileID: 0}
@@ -1155,6 +1161,12 @@ Prefab:
         type: 2}
       propertyPath: Events.Array.data[0].ClassName
       value: InteractableOnFocusReceiver
+      objectReference: {fileID: 0}
+    - target: {fileID: 114818926546564510, guid: 02c524b22137b5449904f5395141cc73,
+        type: 2}
+      propertyPath: Events.Array.data[0].AssemblyQualifiedName
+      value: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events.InteractableOnFocusReceiver,
+        Microsoft.MixedReality.Toolkit.SDK
       objectReference: {fileID: 0}
     - target: {fileID: 114818926546564510, guid: 02c524b22137b5449904f5395141cc73,
         type: 2}

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scenes/InteractablesGallery.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scenes/InteractablesGallery.unity
@@ -504,6 +504,8 @@ MonoBehaviour:
       m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
         Culture=neutral, PublicKeyToken=null
     ClassName: CustomInteractablesReceiver
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events.CustomInteractablesReceiver,
+      MixedRealityToolkit-Examples.Demos.UX.Interactables
     Settings: []
     HideUnityEvents: 1
 --- !u!4 &519184499 stripped
@@ -1855,6 +1857,8 @@ MonoBehaviour:
       m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
         Culture=neutral, PublicKeyToken=null
     ClassName: CustomInteractablesReceiver
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events.CustomInteractablesReceiver,
+      MixedRealityToolkit-Examples.Demos.UX.Interactables
     Settings: []
     HideUnityEvents: 1
 --- !u!4 &1441615695 stripped

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
@@ -22,6 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         public string Name;
         public UnityEvent Event;
         public string ClassName;
+        public string AssemblyQualfiedName;
         public ReceiverBase Receiver;
         public List<InspectorPropertySetting> Settings;
         public bool HideUnityEvents;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.Utilities.InspectorFields;
+using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.TypeResolution;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -27,19 +28,19 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         public List<InspectorPropertySetting> Settings;
         public bool HideUnityEvents;
 
-        public struct EventLists
-        {
-            public List<Type> EventTypes;
-            public List<String> EventNames;
-        }
-        
         public struct ReceiverData
         {
             public string Name;
             public bool HideUnityEvents;
             public List<InspectorFieldData> Fields;
         }
-        
+
+        /// <summary>
+        /// The list of base classes whose derived classes will be included in interactable event
+        /// selection dropdowns.
+        /// </summary>
+        private static readonly List<Type> candidateEventTypes = new List<Type>() { typeof(ReceiverBase) };
+
         public ReceiverData AddOnClick()
         {
             return AddReceiver(typeof(InteractableOnClickReceiver));
@@ -96,41 +97,24 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         /// Get the recieverBase types that contain event logic
         /// </summary>
         /// <returns></returns>
-        public static EventLists GetEventTypes()
+        public static InteractableTypesContainer GetEventTypes()
         {
-            List<Type> eventTypes = new List<Type>();
-            List<string> names = new List<string>();
-            
-            var assemblys = AppDomain.CurrentDomain.GetAssemblies();
-            foreach (var assembly in assemblys)
-            {
-                foreach (Type type in assembly.GetTypes())
-                {
-                    TypeInfo info = type.GetTypeInfo();
-                    if (info.BaseType != null && info.BaseType.Equals(typeof(ReceiverBase)))
-                    {
-                        eventTypes.Add(type);
-                        names.Add(type.Name);
-                    }
-                }
-            }
-
-            EventLists lists = new EventLists();
-            lists.EventTypes = eventTypes;
-            lists.EventNames = names;
-            return lists;
+            return InteractableTypeFinder.Find(candidateEventTypes, InteractableTypeFinder.TypeRestriction.DerivedOnly);
         }
         
         /// <summary>
         /// Create the event and setup the values from the inspector
         /// </summary>
         /// <param name="iEvent"></param>
-        /// <param name="lists"></param>
         /// <returns></returns>
-        public static ReceiverBase GetReceiver(InteractableEvent iEvent, EventLists lists)
+        public static ReceiverBase GetReceiver(InteractableEvent iEvent, InteractableTypesContainer interactableTypes)
         {
-            int index = InspectorField.ReverseLookup(iEvent.ClassName, lists.EventNames.ToArray());
-            Type eventType = lists.EventTypes[index];
+#if UNITY_EDITOR
+            int index = InspectorField.ReverseLookup(iEvent.ClassName, interactableTypes.ClassNames);
+            Type eventType = interactableTypes.Types[index];
+#else
+            Type eventType = Type.GetType(iEvent.AssemblyQualifiedName);
+#endif
             // apply the settings?
             ReceiverBase newEvent = (ReceiverBase)Activator.CreateInstance(eventType, iEvent.Event);
             InspectorGenericFields<ReceiverBase>.LoadSettings(newEvent, iEvent.Settings);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         public string Name;
         public UnityEvent Event;
         public string ClassName;
-        public string AssemblyQualfiedName;
+        public string AssemblyQualifiedName;
         public ReceiverBase Receiver;
         public List<InspectorPropertySetting> Settings;
         public bool HideUnityEvents;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiver.cs
@@ -30,8 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         {
             if (Events.Count > 0)
             {
-                InteractableEvent.EventLists lists = InteractableEvent.GetEventTypes();
-                Events[0].Receiver = InteractableEvent.GetReceiver(Events[0], lists);
+                InteractableTypesContainer interactableTypes = InteractableEvent.GetEventTypes();
+                Events[0].Receiver = InteractableEvent.GetReceiver(Events[0], interactableTypes);
                 Events[0].Receiver.Host = this;
             }
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiverList.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiverList.cs
@@ -29,11 +29,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         /// </summary>
         protected virtual void SetupEvents()
         {
-            InteractableEvent.EventLists lists = InteractableEvent.GetEventTypes();
+            InteractableTypesContainer interactableTypes = InteractableEvent.GetEventTypes();
 
             for (int i = 0; i < Events.Count; i++)
             {
-                Events[i].Receiver = InteractableEvent.GetReceiver(Events[i], lists);
+                Events[i].Receiver = InteractableEvent.GetReceiver(Events[i], interactableTypes);
                 Events[i].Receiver.Host = this;
             }
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -288,14 +288,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         /// </summary>
         protected virtual void SetupEvents()
         {
-            InteractableEvent.EventLists lists = InteractableEvent.GetEventTypes();
-            
+            InteractableTypesContainer interactableTypes = InteractableEvent.GetEventTypes();
+
             for (int i = 0; i < Events.Count; i++)
             {
-                Events[i].Receiver = InteractableEvent.GetReceiver(Events[i], lists);
+                Events[i].Receiver = InteractableEvent.GetReceiver(Events[i], interactableTypes);
                 Events[i].Receiver.Host = this;
-                //Events[i].Settings = InteractableEvent.GetSettings(Events[i].Receiver);
-                // apply settings
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -304,7 +304,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         /// </summary>
         protected virtual void SetupThemes()
         {
-            InteractableProfileItem.ThemeLists lists = InteractableProfileItem.GetThemeTypes();
             runningThemesList = new List<InteractableThemeBase>();
             runningProfileSettings = new List<ProfileSettings>();
             for (int i = 0; i < Profiles.Count; i++)
@@ -322,7 +321,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
                         {
                             InteractableThemePropertySettings settings = theme.Settings[n];
 
-                            settings.Theme = InteractableProfileItem.GetTheme(settings, Profiles[i].Target, lists);
+                            settings.Theme = InteractableProfileItem.GetTheme(settings, Profiles[i].Target);
                             
                             // add themes to theme list based on dimension
                             if (j == dimensionIndex)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile
         public bool HadDefaultTheme;
 
         /// <summary>
-        /// The list of base classes that will be included in interactable theme
+        /// The list of base classes whose derived classes will be included in interactable theme
         /// selection dropdowns.
         /// </summary>
         private static readonly List<Type> candidateThemeTypes = new List<Type>()

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
@@ -54,8 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile
         public static InteractableThemeBase GetTheme(InteractableThemePropertySettings settings, GameObject host)
         {
             Type themeType = Type.GetType(settings.AssemblyQualifiedName);
-            InteractableThemeBase theme = (InteractableThemeBase)Activator.CreateInstance(themeType, host);
-            theme.Init(host ,settings);
+            InteractableThemeBase theme = (InteractableThemeBase)Activator.CreateInstance(themeType);
+            theme.Init(host, settings);
             return theme;
         }
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Utilities.InspectorFields;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes;
+using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.TypeResolution;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -19,44 +20,28 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile
     [System.Serializable]
     public class InteractableProfileItem
     {
-        [System.Serializable]
-        public struct ThemeLists
-        {
-            public List<Type> Types;
-            public List<String> Names;
-        }
-
         public GameObject Target;
         public List<Theme> Themes;
         public bool HadDefaultTheme;
+
+        /// <summary>
+        /// The list of base classes that will be included in interactable theme
+        /// selection dropdowns.
+        /// </summary>
+        private static readonly List<Type> candidateThemeTypes = new List<Type>()
+        {
+            typeof(InteractableThemeBase),
+            typeof(InteractableShaderTheme),
+            typeof(InteractableColorTheme)
+        };
         
         /// <summary>
         /// Get a list of themes
         /// </summary>
         /// <returns></returns>
-        public static ThemeLists GetThemeTypes()
+        public static InteractableTypesContainer GetThemeTypes()
         {
-            List<Type> themeTypes = new List<Type>();
-            List<string> names = new List<string>();
-
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            foreach (var assembly in assemblies)
-            {
-                foreach (Type type in assembly.GetTypes())
-                {
-                    TypeInfo info = type.GetTypeInfo();
-                    if (info.BaseType != null && (info.BaseType.Equals(typeof(InteractableThemeBase)) || info.BaseType.Equals(typeof(InteractableShaderTheme)) || info.BaseType.Equals(typeof(InteractableColorTheme))))
-                    {
-                        themeTypes.Add(type);
-                        names.Add(type.Name);
-                    }
-                }
-            }
-            
-            ThemeLists lists = new ThemeLists();
-            lists.Types = themeTypes;
-            lists.Names = names;
-            return lists;
+            return InteractableTypeFinder.Find(candidateThemeTypes, InteractableTypeFinder.TypeRestriction.DerivedOnly);
         }
 
         /// <summary>
@@ -66,14 +51,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile
         /// <param name="host"></param>
         /// <param name="lists"></param>
         /// <returns></returns>
-        public static InteractableThemeBase GetTheme(InteractableThemePropertySettings settings, GameObject host, ThemeLists lists)
+        public static InteractableThemeBase GetTheme(InteractableThemePropertySettings settings, GameObject host)
         {
-            int index = InspectorField.ReverseLookup(settings.Name, lists.Names.ToArray());
-            Type themeType = lists.Types[index];
+            Type themeType = Type.GetType(settings.AssemblyQualifiedName);
             InteractableThemeBase theme = (InteractableThemeBase)Activator.CreateInstance(themeType, host);
             theme.Init(host ,settings);
             return theme;
         }
-
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.TypeResolution;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,10 +16,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States
         public List<State> StateList;
         public int DefaultIndex = 0;
         public Type StateType;
-        public string[] StateOptions;
-        public Type[] StateTypes;
+        public InteractableTypesContainer StateOptions;
         public string StateLogicName = "InteractableStates";
         public string AssemblyQualifiedName = typeof(InteractableStates).AssemblyQualifiedName;
+
+        /// <summary>
+        /// The list of base classes whose derived classes will be included in interactable state
+        /// selection dropdowns.
+        /// </summary>
+        private static readonly List<Type> candidateStateTypes = new List<Type>() { typeof(InteractableStates) };
 
         //!!! finish making states work, they should initiate the type and run the logic during play mode.
         private void OnEnable()
@@ -33,8 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States
 
         public InteractableStates SetupLogic()
         {
-            int index = ReverseLookup(StateLogicName, StateOptions);
-            StateType = StateTypes[index];
+            StateType = Type.GetType(AssemblyQualifiedName);
             InteractableStates stateLogic = (InteractableStates)Activator.CreateInstance(StateType, StateList[DefaultIndex]);
             List<State> stateListCopy = new List<State>();
             for (int i = 0; i < StateList.Count; i++)
@@ -54,26 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States
 
         public void SetupStateOptions()
         {
-            List<Type> stateTypes = new List<Type>();
-            List<string> names = new List<string>();
-
-
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            foreach (var assembly in assemblies)
-            {
-                foreach (Type type in assembly.GetTypes())
-                {
-                    TypeInfo info = type.GetTypeInfo();
-                    if (info.BaseType != null && (info.BaseType.Equals(typeof(InteractableStates)) || type.Equals(typeof(InteractableStates))))
-                    {
-                        stateTypes.Add(type);
-                        names.Add(type.Name);
-                    }
-                }
-            }
-
-            StateOptions = names.ToArray();
-            StateTypes = stateTypes.ToArray();
+            StateOptions = InteractableTypeFinder.Find(candidateStateTypes, InteractableTypeFinder.TypeRestriction.AllowBase);
         }
 
         // redundant method, put in a utils with static methods!!!

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States
         public string[] StateOptions;
         public Type[] StateTypes;
         public string StateLogicName = "InteractableStates";
+        public string AssemblyQualifiedName = typeof(InteractableStates).AssemblyQualifiedName;
 
         //!!! finish making states work, they should initiate the type and run the logic during play mode.
         private void OnEnable()

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeBase.cs
@@ -22,6 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public Easing Ease;
         public bool NoEasing;
         public bool Loaded;
+        public string AssemblyQualifiedName;
 
         private bool hasFirstState = false;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertySettings.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertySettings.cs
@@ -43,6 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     public struct InteractableThemePropertySettings
     {
         public string Name;
+        public string AssemblyQualifiedName;
         public Type Type;
         public InteractableThemeBase Theme;
         public List<InteractableThemeProperty> Properties;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a150b8fba33bb24482cd83a1449c57b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableType.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableType.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
+{
+    /// <summary>
+    /// A wrapper for a Type which gives a "friendly name" for the type (i.e.
+    /// the class name) along with the assembly qualified name (which can be used
+    /// to new instances of this type). 
+    /// </summary>
+    /// <remarks>
+    /// The intent of this wrapper is for use with the various Interactable state, event
+    /// and theme classes, which are enumerated using reflection in the editor but must
+    /// then be instantiated at runtime (without the usage of reflection due to .NET
+    /// backend constraints).
+    /// </remarks>
+    public class InteractableType
+    {
+        /// <summary>
+        /// The class name of this interactable type (for example, "InteractableActivateTheme").
+        /// </summary>
+        public string ClassName { get; private set; }
+
+        /// <summary>
+        /// The assembly qualified name of the class (for example, 
+        /// "Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableActivateTheme, 
+        /// Microsoft.MixedReality.Toolkit.SDK")
+        /// </summary>
+        public string AssemblyQualifiedName { get; private set; }
+
+        /// <summary>
+        /// The type of the class (for example, typeof(InteractableActivateTheme)).
+        /// </summary>
+        public Type Type { get; private set; }
+
+        public InteractableType(Type type)
+        {
+            ClassName = type.Name;
+            AssemblyQualifiedName = SystemType.GetReference(type);
+            Type = type;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableType.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15b7c678481633144aabbd887cbefec9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.TypeResolution
             // Due to other code structure, it's possible that this can still be invoked at runtime, but should
             // not return anything (because type information should be read from serialized assembly data, rather
             // than using reflection at runtime).
-            return new InteractableTypeList(new List<InteractableType>());
+            return new InteractableTypesContainer(new List<InteractableType>());
 #endif
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.TypeResolution
+{
+    /// <summary>
+    /// A helper that uses reflection to find objects that implement base types of the
+    /// Interactable types that populate the various state, theme, and event inspectors.
+    /// </summary>
+    /// <remarks>
+    /// 
+    /// </remarks>
+    public class InteractableTypeFinder
+    {
+        /// <summary>
+        /// Controls the behavior of the InteractableTypeFinder.FindTypes function. See individual
+        /// enum values for more details.
+        /// </summary>
+        public enum TypeRestriction
+        {
+            /// <summary>
+            /// When this is specified, only classes derived from the specified type will be
+            /// returned by the lookup. This means that if you pass InteractableStates, the
+            /// lookup will only return classes whose base class is InteractableStates but
+            /// will not return InteractableStates itself.
+            /// </summary>
+            DerivedOnly,
+
+            /// <summary>
+            /// When this is specified, classes derived from the specified type AND the class
+            /// itself will be returned by the lookup. This means that if you pass 
+            /// InteractableStates, the lookup will both classes whose base class is 
+            /// InteractableStates and InteractableStates itself.
+            /// </summary>
+            AllowBase,
+        };
+
+        /// <summary>
+        /// A convenience wrapper provided for editor code to turn a list of types into a form that 
+        /// matches their existing structure.
+        /// </summary>
+        /// <remarks>
+        /// This is primarily a crutch because of how the inspector code stores parallel arrays of
+        /// objects, rather than just storing an array of objects (i.e. it stores three arrays
+        /// of objects which happen to have matching indices, rather than storing a single array
+        /// of objects which have state relevant within the object).
+        /// </remarks>
+        public static InteractableTypesContainer Find(List<Type> types, TypeRestriction typeRestriction)
+        {
+#if UNITY_EDITOR
+            return new InteractableTypesContainer(FindTypes(types, typeRestriction));
+#else
+            // Due to other code structure, it's possible that this can still be invoked at runtime, but should
+            // not return anything (because type information should be read from serialized assembly data, rather
+            // than using reflection at runtime).
+            return new InteractableTypeList(new List<InteractableType>());
+#endif
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Used to cache lookups for Types (for example, InteractableThemeBase) to their classes that implement
+        /// that type.
+        /// </summary>
+        private static Dictionary<Type, List<InteractableType>> cache = new Dictionary<Type, List<InteractableType>>();
+
+        /// <summary>
+        /// Gets the list of InteractableType objects for classes that support the specified types.
+        /// </summary>
+        private static List<InteractableType> FindTypes(List<Type> types, TypeRestriction typeRestriction)
+        {
+            EnsureCacheForTypes(types, typeRestriction);
+            return GetTypesFromCache(types);
+        }
+
+        /// <summary>
+        /// Gets the list of InteractableType objects for classes that support the specified types by
+        /// looking directly in the cache.
+        /// </summary>
+        /// <remarks>
+        /// Assumes it is called after EnsureCacheForTypes. Otherwise, this is dangerous to call.
+        /// </remarks>
+        private static List<InteractableType> GetTypesFromCache(List<Type> types)
+        {
+            List<InteractableType> interactableTypes = new List<InteractableType>();
+            foreach (Type type in types)
+            {
+                interactableTypes.AddRange(cache[type]);
+            }
+            return interactableTypes;
+        }
+
+        /// <summary>
+        /// Ensures a cache entry is setup for all types in the InteractableType enum.
+        /// </summary>
+        /// <remarks>
+        /// Note that this is not invoked at runtime and is assumed to be invoked from a single
+        /// threaded UI context, and is thus not locked.
+        /// </remarks>
+        private static void EnsureCacheForTypes(List<Type> types, TypeRestriction typeRestriction)
+        {
+            List<Type> cacheMisses = new List<Type>();
+            foreach (Type type in types)
+            {
+                if (!cache.ContainsKey(type))
+                {
+                    cacheMisses.Add(type);
+                }
+            }
+
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (Type type in cacheMisses)
+            {
+                cache[type] = GetTypesFromAssemblies(type, typeRestriction, assemblies);
+            }
+        }
+
+        /// <summary>
+        /// Loads the classes that derive from the given type by looking through all of the assemblies.
+        /// </summary>
+        private static List<InteractableType> GetTypesFromAssemblies(Type type, TypeRestriction typeRestriction, Assembly[] assemblies)
+        {
+            List<InteractableType> interactableTypes = new List<InteractableType>();
+            foreach (Assembly assembly in assemblies)
+            {
+                foreach (Type assemblyType in assembly.GetTypes())
+                {
+                    TypeInfo info = assemblyType.GetTypeInfo();
+                    bool exactBaseMatch = typeRestriction == TypeRestriction.AllowBase && assemblyType.Equals(type);
+                    bool derivedMatch = info.BaseType != null && info.BaseType.Equals(type);
+                    if (exactBaseMatch || derivedMatch)
+                    {
+                        InteractableType interactableType = new InteractableType(assemblyType);
+                        interactableTypes.Add(interactableType);
+                    }
+                }
+            }
+            return interactableTypes;
+        }
+#endif
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs
@@ -8,9 +8,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.TypeResolution
     /// A helper that uses reflection to find objects that implement base types of the
     /// Interactable types that populate the various state, theme, and event inspectors.
     /// </summary>
-    /// <remarks>
-    /// 
-    /// </remarks>
     public class InteractableTypeFinder
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17f97948b2a5c3d4882917d00130da48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypesContainer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypesContainer.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
+{
+    /// <summary>
+    /// A convenience class that holds arrays of class names, fully qualified assembly names
+    /// and their corresponding actual types.
+    /// </summary>
+    /// <remarks>
+    /// This abstraction exists primarily to reduce code duplication among the different
+    /// inspectors which use these lists to populate their dropdowns.
+    /// 
+    /// Note that all of these arrays are the same size and come in the same order
+    /// (so for example, ClassName[0] = "InteractableActivateTheme" means that
+    /// Types[0] == typeof(InteractableActivateTheme) and AssemblyQualifiedNames
+    /// is the assembly qualified name for InteractableActivateTheme.
+    /// </remarks>
+    public class InteractableTypesContainer
+    {
+        /// <summary>
+        /// An array of class names (for example, "InteractableActivateTheme").
+        /// </summary>
+        public string[] ClassNames { get; private set; }
+
+        /// <summary>
+        /// A array of assembly qualified names (for example, 
+        /// "Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableActivateTheme, 
+        /// Microsoft.MixedReality.Toolkit.SDK")
+        /// </summary>
+        public string[] AssemblyQualifiedNames { get; private set; }
+
+        /// <summary>
+        /// An array of types. See class remarks for more information on relation to
+        /// other fields.
+        /// </summary>
+        public Type[] Types { get; private set; }
+
+        /// <summary>
+        /// A convenience helper that will unwrap a list of InteractableType objects into
+        /// a form that is more easy consumed by inspector components.
+        /// </summary>
+        public InteractableTypesContainer(List<InteractableType> interactableTypes)
+        {
+            var classNames = new List<string>();
+            var assemblyQualifiedNames = new List<string>();
+            var types = new List<Type>();
+
+            for (int i = 0; i < interactableTypes.Count; i++)
+            {
+                classNames.Add(interactableTypes[i].ClassName);
+                assemblyQualifiedNames.Add(interactableTypes[i].AssemblyQualifiedName);
+                types.Add(interactableTypes[i].Type);
+            }
+
+            ClassNames = classNames.ToArray();
+            AssemblyQualifiedNames = assemblyQualifiedNames.ToArray();
+            Types = types.ToArray();
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypesContainer.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypesContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36cfbe5dd842571498f11ba8e031b7f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset
@@ -36,3 +36,5 @@ MonoBehaviour:
   StateOptions:
   - InteractableStates
   StateLogicName: InteractableStates
+  AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States.InteractableStates,
+    Microsoft.MixedReality.Toolkit.SDK

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/HoloLensInteractableStates.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/HoloLensInteractableStates.asset
@@ -46,3 +46,5 @@ MonoBehaviour:
   StateOptions:
   - InteractableStates
   StateLogicName: InteractableStates
+  AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States.InteractableStates,
+    Microsoft.MixedReality.Toolkit.SDK

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/AnimatorTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/AnimatorTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableAnimatorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableAnimatorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Animator Trigger
       Type: 16

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackground.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackground.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackgroundSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackgroundSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBorders.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBorders.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorChildrenTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorChildrenTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBordersSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBordersSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorChildrenTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorChildrenTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabel.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabel.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelColor.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelColor.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/CheeseTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/CheeseTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/CoffeeTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/CoffeeTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/CylinderTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/CylinderTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/DefaultTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/DefaultTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlate.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlate.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlateToggleSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlateToggleSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonFrontPlate.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonFrontPlate.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableShaderTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableShaderTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Shader
       Type: 3
@@ -654,6 +656,8 @@ MonoBehaviour:
       Target: {fileID: 0}
       States: []
   - Name: InteractableColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableScaleTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableScaleTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_IcosaTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_IcosaTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableShaderTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableShaderTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Shader
       Type: 3
@@ -872,6 +874,8 @@ MonoBehaviour:
         Value: 0
         ActiveIndex: 3
   - Name: InteractableShaderTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableShaderTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Shader
       Type: 3

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackground.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackground.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackgroundSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackgroundSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: InteractableColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Color
       Type: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButton.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButton.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButtonSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButtonSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDot.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDot.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDotSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDotSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIcon.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIcon.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6
@@ -648,6 +650,8 @@ MonoBehaviour:
       Target: {fileID: 0}
       States: []
   - Name: InteractableActivateTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableActivateTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Activate
       Type: 15

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIconSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIconSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6
@@ -648,6 +650,8 @@ MonoBehaviour:
       Target: {fileID: 0}
       States: []
   - Name: InteractableActivateTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.InteractableActivateTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Activate
       Type: 15

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabel.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabel.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabelSelected.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabelSelected.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ballonTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ballonTheme.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   Name: 
   Settings:
   - Name: ScaleOffsetColorTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes.ScaleOffsetColorTheme,
+      Microsoft.MixedReality.Toolkit.SDK
     Properties:
     - Name: Scale
       Type: 6

--- a/Assets/MixedRealityToolkit.SDK/Features/toc.yml.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/toc.yml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90d118096da105b4aa0798c27af6b295
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -675,12 +675,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             SerializedProperty name = prop.FindPropertyRelative("Name");
             SerializedProperty settings = prop.FindPropertyRelative("Settings");
             SerializedProperty hideEvents = prop.FindPropertyRelative("HideUnityEvents");
+            SerializedProperty assemblyQualifiedName = prop.FindPropertyRelative("AssemblyQualifiedName");
 
             if (!String.IsNullOrEmpty(className.stringValue))
             {
-                InteractableEvent.ReceiverData data = eventList[indexArray[0]].AddReceiver(eventTypes[indexArray[1]]);
+                InteractableEvent.ReceiverData data = eventList[indexArray[0]].AddReceiver(eventOptions.Types[indexArray[1]]);
                 name.stringValue = data.Name;
                 hideEvents.boolValue = data.HideUnityEvents;
+                assemblyQualifiedName.stringValue = eventOptions.AssemblyQualifiedNames[indexArray[1]];
 
                 InspectorFieldsUtility.PropertySettingsList(settings, data.Fields);
             }

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -31,10 +31,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         protected string prefKey = "InteractableInspectorProfiles";
         protected bool enabled = false;
 
-        protected string[] eventOptions;
-        protected Type[] eventTypes;
-        protected string[] themeOptions;
-        protected Type[] themeTypes;
+        protected InteractableTypesContainer eventOptions;
+        protected InteractableTypesContainer themeOptions;
         protected string[] shaderOptions;
 
         protected string[] actionOptions;
@@ -497,7 +495,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
                 InteractableReceiverListInspector.RenderEventSettings(eventItem, i, eventOptions, ChangeEvent, RemoveEvent);
             }
 
-            if (eventOptions.Length > 1)
+            if (eventOptions.ClassNames.Length > 1)
             {
                 if (GUILayout.Button(new GUIContent("Add Event")))
                 {
@@ -546,9 +544,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
          
         protected void SetupThemeOptions()
         {
-            InteractableProfileItem.ThemeLists lists = InteractableProfileItem.GetThemeTypes();
-            themeOptions = lists.Names.ToArray();
-            themeTypes = lists.Types.ToArray();
+            themeOptions = InteractableProfileItem.GetThemeTypes();
         }
 
         protected virtual void AddThemeProperty(int[] arr, SerializedProperty prop = null)
@@ -569,13 +565,16 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 
             SerializedProperty settingsItem = themeObjSettings.GetArrayElementAtIndex(themeObjSettings.arraySize-1);
             SerializedProperty className = settingsItem.FindPropertyRelative("Name");
+            SerializedProperty assemblyQualifiedName = settingsItem.FindPropertyRelative("AssemblyQualifiedName");
             if (themeObjSettings.arraySize == 1) {
                 
                 className.stringValue = "ScaleOffsetColorTheme";
+                assemblyQualifiedName.stringValue = typeof(ScaleOffsetColorTheme).AssemblyQualifiedName;
             }
             else
             {
-                className.stringValue = themeOptions[0];
+                className.stringValue = themeOptions.ClassNames[0];
+                assemblyQualifiedName.stringValue = themeOptions.AssemblyQualifiedNames[0];
             }
 
             SerializedProperty easing = settingsItem.FindPropertyRelative("Easing");
@@ -689,11 +688,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         
         protected void SetupEventOptions()
         {
-            InteractableEvent.EventLists lists = InteractableEvent.GetEventTypes();
-            eventTypes = lists.EventTypes.ToArray();
-            eventOptions = lists.EventNames.ToArray();
+            eventOptions = InteractableEvent.GetEventTypes();
         }
-        
     }
 #endif
 }

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/StatesInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/StatesInspector.cs
@@ -18,13 +18,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States
         protected States instance;
         protected SerializedProperty stateList;
 
-        // list of InteractableStates
-        protected Type[] stateTypes;
-
-        // list of State names
-        protected string[] stateOptions;
-
-
+        // List of interactable states.
+        protected InteractableTypesContainer stateOptions;
+        
         // indent tracker
         protected static int indentOnSectionStart = 0;
 
@@ -47,15 +43,16 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States
 
             // get the list of options and InteractableStates
             stateOptions = instance.StateOptions;
-            stateTypes = instance.StateTypes;
             
             SerializedProperty stateLogicName = serializedObject.FindProperty("StateLogicName");
-            int option = States.ReverseLookup(stateLogicName.stringValue, stateOptions);
+            SerializedProperty assemblyQualifiedName  = serializedObject.FindProperty("AssemblyQualifiedName");
+            int option = States.ReverseLookup(stateLogicName.stringValue, stateOptions.ClassNames);
 
-            int newLogic = EditorGUILayout.Popup("State Model", option, stateOptions);
+            int newLogic = EditorGUILayout.Popup("State Model", option, stateOptions.ClassNames);
             if (option != newLogic)
             {
-                stateLogicName.stringValue = stateOptions[newLogic];
+                stateLogicName.stringValue = stateOptions.ClassNames[newLogic];
+                assemblyQualifiedName.stringValue = stateOptions.AssemblyQualifiedNames[newLogic];
             }
 
             int bitCount = 0;

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityControllerAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityControllerAttribute.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using System;
 using System.Linq;
+using System.Reflection;
 
 #if WINDOWS_UWP && !ENABLE_IL2CPP
 using Microsoft.MixedReality.Toolkit.Core.Extensions;
@@ -60,9 +61,18 @@ namespace Microsoft.MixedReality.Toolkit.Core.Attributes
         /// <summary>
         /// Convenience function for retrieving the attribute given a certain class type.
         /// </summary>
+        /// <remarks>
+        /// This function is only available in a UnityEditor context.
+        /// </remarks>
         public static MixedRealityControllerAttribute Find(Type type)
         {
+#if WINDOWS_UWP && !ENABLE_IL2CPP
+            // Type.GetCustomAttributes() doesn't exist on UWP .NET, so we have to indirectly use
+            // the TypeInfo instead.
+            return type.GetTypeInfo().GetCustomAttributes(typeof(MixedRealityControllerAttribute), true).FirstOrDefault() as MixedRealityControllerAttribute;
+#else
             return type.GetCustomAttributes(typeof(MixedRealityControllerAttribute), true).FirstOrDefault() as MixedRealityControllerAttribute;
+#endif
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
@@ -76,7 +76,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Attributes
         /// </summary>
         public static MixedRealityExtensionServiceAttribute Find(Type type)
         {
+#if WINDOWS_UWP && !ENABLE_IL2CPP
+            // Type.GetCustomAttributes() doesn't exist on UWP .NET, so we have to indirectly use
+            // the TypeInfo instead.
+            return type.GetTypeInfo().GetCustomAttributes(typeof(MixedRealityExtensionServiceAttribute), true).FirstOrDefault() as MixedRealityExtensionServiceAttribute;
+#else
             return type.GetCustomAttributes(typeof(MixedRealityExtensionServiceAttribute), true).FirstOrDefault() as MixedRealityExtensionServiceAttribute;
+#endif
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using System;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
 
 #if UNITY_EDITOR


### PR DESCRIPTION
Given that we have customers who are migrating from HTK to MRTK and need to continue to work on the .NET backend, we need to keep supporting this until Unity itself gets rid of .NET backend support.

This change is broken up into some less complex things (which we will describe first) and some more complex things (serializing actual assembly types instead of doing runtime based reflection).

Note that this is actually a breaking change for people who have defined their own assets that use the interactable based theme/event/state systems. The way to migrate is to do the similar .asset/.unity filechanges included in this PR (i.e. adding a proto field that is the AssemblyQualifiedName). My hope is that I might be able to just write a migrator script to make this easier.

Less complex things:
[Certain Types APIs](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.getcustomattributes?view=netframework-4.7.2#System_Reflection_MemberInfo_GetCustomAttributes_System_Type_System_Boolean_) aren't supported in UWP .NET, but thankfully have a workaround (i.e. getting the type info and going from there).

More complex things:
The rest of the changes have to deal with the fundamental issues around using APIs that don't exist in UWP .NET (i.e. AppDomain). Unfortunately, there isn't even a replacement for these (yes, it's possible to enumerate through the installed app's DLLs, but on master unity releases i.e. when the customer actually pushes the app for real, those assemblies are all removed). Fundamentally, we shouldn't be using reflection at runtime to power dependency hookup behavior (there are other patterns we can follow i.e. DI, Service locators, lotsa other stuff).

I ultimately chose to implement things this way as a workaround, not because I believe this is fundamentally the right long term approach (i.e. I want us to be able to figure out the best way of authoring easy to use UI helpers which properly hookup dependencies), but because we have an immediate need to have .NET backend support working, and doing this this way would be the least "destructive" of the common MRTK use case.

I could have, for example, done this using SciprtableObjects (as singletons) but would need to attach these objects to SOME object in the scene (which would have messied the scene graph).

I could have added some other profile based system to the MRTK, but I want to get wide buy-in first that such a thing makes sense.

The drawback of this approach comes from the fact that now future refactors of the namespace of these objects will require additional asset changes (see the asset things that I've done).